### PR TITLE
Fix possible null value returned by getComputedStyle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,9 +51,13 @@ export default class ResizeObserverLite {
 }
 
 function getSize(element: Element): ResizeObserverSize {
+  const computedStyle = window.getComputedStyle(element) || {
+    width: 0,
+    height: 0
+  };
   return {
-    width: getNumber(window.getComputedStyle(element)['width']!),
-    height: getNumber(window.getComputedStyle(element)['height']!)
+    width: getNumber(computedStyle['width']!),
+    height: getNumber(computedStyle['height']!)
   };
 }
 


### PR DESCRIPTION
There is a possibility of `getComputedStyle` returning `null`, for example, [this Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=548397).

This PR makes sure there won't be a `TypeError: window.getComputedStyle(...) is null)` error in such case, and returns zeroes for the `width` and `height` if this happens.